### PR TITLE
Update the trends deployment

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -10,13 +10,13 @@ services:
             - "5672:5672"
 
     worker:
-        image: gcr.io/trends-217607/trends
+        image: 
         command: celery -A trends worker
         depends_on:
             - rabbit
 
     web:
-        image: gcr.io/trends-217607/trends
+        image: 
         command: celery -A trends flower --port=80
         ports:
             - "80:80"


### PR DESCRIPTION
This commit updates the trends deployment container image to:

    

Build ID: 8c696ede-2036-4745-9c79-79adab775064