### PR TITLE
Update the trends deployment

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -10,13 +10,13 @@ services:
             - "5672:5672"
 
     worker:
-        image: gcr.io/trends-217607/trends
+        image: 
         command: celery -A trends worker
         depends_on:
             - rabbit
 
     web:
-        image: gcr.io/trends-217607/trends
+        image: 
         command: celery -A trends flower --port=80
         ports:
             - "80:80"


### PR DESCRIPTION
This commit updates the trends deployment container image to:

    

Build ID: 51e875c6-38ac-4c81-a894-d2098df4bf2a