### PR TITLE
Update the trends deployment

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -10,13 +10,13 @@ services:
             - "5672:5672"
 
     worker:
-        image: 
+        image: gcr.io/trends-217607/trends:1.0.4
         command: celery -A trends worker
         depends_on:
             - rabbit
 
     web:
-        image: 
+        image: gcr.io/trends-217607/trends:1.0.4
         command: celery -A trends flower --port=80
         ports:
             - "80:80"


### PR DESCRIPTION
This commit updates the trends deployment container image to:

    gcr.io/trends-217607/trends:1.0.4

Build ID: 688aa6b7-3636-4dd6-8b4c-f816fbea5552