### PR TITLE
Update the trends deployment

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -10,13 +10,13 @@ services:
             - "5672:5672"
 
     worker:
-        image: gcr.io/trends-217607/trends:1.0.4
+        image: gcr.io/trends-217607/trends:1.0.5
         command: celery -A trends worker
         depends_on:
             - rabbit
 
     web:
-        image: gcr.io/trends-217607/trends:1.0.4
+        image: gcr.io/trends-217607/trends:1.0.5
         command: celery -A trends flower --port=80
         ports:
             - "80:80"


### PR DESCRIPTION
This commit updates the trends deployment container image to:

    gcr.io/trends-217607/trends:1.0.5

Build ID: 20f2841a-d250-40dc-b468-eaaab172a64c